### PR TITLE
Display partner profile during voice calls

### DIFF
--- a/app/app/voice/page.tsx
+++ b/app/app/voice/page.tsx
@@ -29,7 +29,7 @@ export default function VoicePage() {
   const [remainingSeconds, setRemainingSeconds] = useState(1200) // 20 minutes
   const [, setCallId] = useState<string | null>(null)
   const [decision, setDecision] = useState<"stay" | "skip" | null>(null)
-  const [partner, setPartner] = useState<{ name: string; avatar?: string; id: string } | null>(null)
+  const [partner, setPartner] = useState<{ name: string; avatar: string; id: string } | null>(null)
   const [waitingMessageIndex, setWaitingMessageIndex] = useState(0)
   
   const signalingRef = useRef<SignalingClient | null>(null)
@@ -179,14 +179,17 @@ export default function VoicePage() {
         async (
           role: 'offerer' | 'answerer',
           callId: string,
-          partner?: { name: string; avatar?: string; id: string }
+          partner: { name: string; avatar: string; id: string }
         ) => {
           console.log(`[Voice] Paired as ${role} for call ${callId}`, partner)
           setCallId(callId)
 
-          if (!partner) {
-            // No partner ready yet, keep searching
-            setPartner(null)
+          if (!partner?.name || !partner?.avatar) {
+            toast({
+              title: 'Profile required',
+              description: 'Could not load partner profile',
+              variant: 'destructive'
+            })
             setState('searching')
             return
           }
@@ -539,7 +542,7 @@ export default function VoicePage() {
             <div className="space-y-3">
               <div className="relative">
                 <Avatar className="h-24 w-24 mx-auto">
-                  <AvatarImage src={partner?.avatar} alt={partner?.name || "User"} />
+                  <AvatarImage src={partner?.avatar} alt={partner?.name} />
                   <AvatarFallback className="text-2xl">
                     {partner?.name?.charAt(0)?.toUpperCase() || "?"}
                   </AvatarFallback>
@@ -551,7 +554,7 @@ export default function VoicePage() {
                 </div>
               </div>
               <div className="space-y-1">
-                <h3 className="text-xl font-semibold">{partner?.name || "Someone"}</h3>
+                <h3 className="text-xl font-semibold">{partner?.name}</h3>
                 <p className="text-sm text-muted-foreground">wants to voice chat with you</p>
               </div>
             </div>
@@ -587,13 +590,13 @@ export default function VoicePage() {
             {partner && (
               <div className="space-y-3">
                 <Avatar className="h-20 w-20 mx-auto">
-                  <AvatarImage src={partner?.avatar} alt={partner?.name || "User"} />
+                  <AvatarImage src={partner?.avatar} alt={partner?.name} />
                   <AvatarFallback className="text-lg">
                     {partner?.name?.charAt(0)?.toUpperCase() || "?"}
                   </AvatarFallback>
                 </Avatar>
                 <div className="space-y-1">
-                  <h3 className="text-lg font-semibold">{partner?.name || "Waiting..."}</h3>
+                  <h3 className="text-lg font-semibold">{partner?.name}</h3>
                   <p className="text-sm text-muted-foreground">Waiting for the other person to connect…</p>
                 </div>
               </div>
@@ -615,12 +618,12 @@ export default function VoicePage() {
             {partner && (
               <div className="space-y-3">
                 <Avatar className="h-20 w-20 mx-auto">
-                  <AvatarImage src={partner?.avatar} alt={partner?.name || "User"} />
+                  <AvatarImage src={partner?.avatar} alt={partner?.name} />
                   <AvatarFallback className="text-lg">
                     {partner?.name?.charAt(0)?.toUpperCase() || "?"}
                   </AvatarFallback>
                 </Avatar>
-                <h3 className="text-lg font-semibold">{partner?.name || "Voice Chat"}</h3>
+                <h3 className="text-lg font-semibold">{partner?.name}</h3>
               </div>
             )}
             <div className="space-y-2">

--- a/lib/voice/signaling.ts
+++ b/lib/voice/signaling.ts
@@ -5,10 +5,14 @@ export type SignalingState = 'disconnected' | 'connecting' | 'queued' | 'paired'
 export type ServerMessage =
   | {
       type: 'status'
-      state: 'queued' | 'paired'
-      role?: 'offerer' | 'answerer'
-      callId?: string
-      partner?: { name: string; avatar?: string; id: string }
+      state: 'queued'
+    }
+  | {
+      type: 'status'
+      state: 'paired'
+      role: 'offerer' | 'answerer'
+      callId: string
+      partner: { name: string; avatar: string; id: string }
     }
   | { type: 'offer'; sdp: RTCSessionDescriptionInit }
   | { type: 'answer'; sdp: RTCSessionDescriptionInit }
@@ -25,7 +29,7 @@ export type ServerMessage =
 
 export interface SignalingEvents {
   onStateChange: (state: SignalingState) => void
-  onPaired: (role: 'offerer' | 'answerer', callId: string, partner?: { name: string; avatar?: string; id: string }) => void
+  onPaired: (role: 'offerer' | 'answerer', callId: string, partner: { name: string; avatar: string; id: string }) => void
   onOffer: (sdp: RTCSessionDescriptionInit) => void
   onAnswer: (sdp: RTCSessionDescriptionInit) => void
   onIceCandidate: (candidate: RTCIceCandidateInit) => void
@@ -177,7 +181,7 @@ export class SignalingClient {
       case 'status':
         if (message.state === 'queued') {
           this.updateState('queued')
-        } else if (message.state === 'paired' && message.role && message.callId) {
+        } else if (message.state === 'paired') {
           this.updateState('paired')
           this.events.onPaired?.(message.role, message.callId, message.partner)
         }

--- a/pharmx-worker-api/src/durable-objects/LobbyDO.ts
+++ b/pharmx-worker-api/src/durable-objects/LobbyDO.ts
@@ -12,7 +12,7 @@ interface User {
   acceptedCall?: boolean
   profile?: {
     name: string
-    avatar?: string
+    avatar: string
     id: string
   }
 }
@@ -39,7 +39,8 @@ type ClientMessage =
   | { type: 'ping' }
 
 type ServerMessage =
-  | { type: 'status'; state: 'queued' | 'paired'; role?: 'offerer' | 'answerer'; callId?: string; partner?: { name: string; avatar?: string; id: string } }
+  | { type: 'status'; state: 'queued' }
+  | { type: 'status'; state: 'paired'; role: 'offerer' | 'answerer'; callId: string; partner: { name: string; avatar: string; id: string } }
   | { type: 'offer'; sdp: any }
   | { type: 'answer'; sdp: any }
   | { type: 'ice'; candidate: any }
@@ -650,7 +651,7 @@ export class LobbyDO {
     }
   }
 
-  private async fetchUserProfile(userId: string): Promise<{ name: string; avatar?: string; id: string }> {
+  private async fetchUserProfile(userId: string): Promise<{ name: string; avatar: string; id: string }> {
     try {
       const result = await this.env.DB.prepare(
         'SELECT id, name, avatar_url FROM users WHERE id = ?'
@@ -660,7 +661,7 @@ export class LobbyDO {
         return {
           id: result.id,
           name: result.name || 'Anonymous',
-          avatar: result.avatar_url
+          avatar: result.avatar_url || ''
         }
       }
     } catch (e) {
@@ -670,7 +671,8 @@ export class LobbyDO {
     // Fallback profile
     return {
       id: userId,
-      name: 'Anonymous'
+      name: 'Anonymous',
+      avatar: ''
     }
   }
 


### PR DESCRIPTION
## Summary
- require partner details from signaling messages
- show matched user's avatar and name throughout call flow
- return to search if partner profile cannot be loaded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a80ba0624c832dbe076950313fb43e