### PR TITLE
fix: prevent header shift on desktop

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,6 +73,6 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-y-scroll;
   }
 }


### PR DESCRIPTION
## Summary
- ensure body always reserves space for a scrollbar to avoid header movement between pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a80f2c7d20832d9684c32c428c97c7