### PR TITLE
Remove discover banner and obsolete settings entries

### DIFF
--- a/app/app/users/page.tsx
+++ b/app/app/users/page.tsx
@@ -103,14 +103,6 @@ export default function UsersPage() {
 
   return (
     <div className="container max-w-6xl mx-auto px-2 sm:px-4 py-4">
-      {/* Header */}
-      <div className="mb-4 px-2">
-        <h1 className="text-2xl font-bold">Discover</h1>
-        <p className="text-sm text-muted-foreground">
-          Find people nearby to connect with
-        </p>
-      </div>
-
       {/* User Grid - Picture Focused */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2 sm:gap-3">
         {mockUsers.map((user) => {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -5,15 +5,14 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Switch } from "@/components/ui/switch"
-import { 
-  ChevronRight, 
-  Bookmark, 
-  FileText, 
-  User, 
-  MessageSquare, 
-  Bell, 
-  Shield, 
-  HelpCircle, 
+import {
+  ChevronRight,
+  FileText,
+  User,
+  MessageSquare,
+  Bell,
+  Shield,
+  HelpCircle,
   Users,
   // CreditCard, // Removed - not used
   Moon,
@@ -29,20 +28,6 @@ import { useToast } from "@/hooks/use-toast"
 import { apiClient } from "@/lib/api-client"
 
 const settingsItems = [
-  {
-    id: "saved",
-    icon: Bookmark,
-    label: "Saved Topics",
-    href: "/settings/saved",
-    badge: null
-  },
-  {
-    id: "notes",
-    icon: FileText,
-    label: "My Notes",
-    href: "/settings/notes",
-    badge: null
-  },
   {
     id: "account",
     icon: User,


### PR DESCRIPTION
## Summary
- drop "Discover" heading and subtitle from user grid
- remove Saved Topics and My Notes from settings menu

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8115433a0832d8063dbbed1431794