### PR TITLE
Allow voice calls without avatar

### DIFF
--- a/app/app/voice/page.tsx
+++ b/app/app/voice/page.tsx
@@ -10,6 +10,13 @@ import { SignalingClient, SignalingEventType } from "@/lib/voice/signaling"
 import { useRouter } from "next/navigation"
 import { apiClient } from "@/lib/api-client"
 
+const withApiBase = (url?: string) => {
+  if (!url) return ""
+  if (url.startsWith("http")) return url
+  const base = process.env.NEXT_PUBLIC_API_URL || ""
+  return `${base}${url}`
+}
+
 type VoiceState = "idle" | "searching" | "incoming_call" | "connecting" | "in_call" | "deciding" | "waiting_decision"
 
 // Engaging waiting messages that rotate during search
@@ -184,7 +191,7 @@ export default function VoicePage() {
           console.log(`[Voice] Paired as ${role} for call ${callId}`, partner)
           setCallId(callId)
 
-          if (!partner?.name || !partner?.avatar) {
+          if (!partner?.name) {
             toast({
               title: 'Profile required',
               description: 'Could not load partner profile',
@@ -194,7 +201,8 @@ export default function VoicePage() {
             return
           }
 
-          setPartner(partner)
+          // Ensure avatar URL is absolute; UI will show fallback if still missing
+          setPartner({ ...partner, avatar: withApiBase(partner.avatar) })
 
           if (role === 'answerer') {
             // Show accept/decline for the receiver

--- a/app/settings/account/page.tsx
+++ b/app/settings/account/page.tsx
@@ -16,6 +16,13 @@ import { ChevronRight, Camera, User, Loader2 } from "lucide-react"
 import Link from "next/link"
 import { apiClient } from "@/lib/api-client"
 
+const withApiBase = (url?: string | null) => {
+  if (!url) return ""
+  if (url.startsWith("http")) return url
+  const base = process.env.NEXT_PUBLIC_API_URL || ""
+  return `${base}${url}`
+}
+
 const profileSchema = z.object({
   name: z.string().min(2).max(40),
   gender: z.enum(["male", "female"]),
@@ -81,7 +88,7 @@ export default function AccountSettingsPage() {
       }
       
       setUser(profile)
-      setAvatarPreview(profile.avatarUrl || '')
+      setAvatarPreview(withApiBase(profile.avatarUrl))
       
       // Set form values
       setValue("name", profile.name)
@@ -134,6 +141,7 @@ export default function AccountSettingsPage() {
     try {
       const result = await apiClient.profile.uploadAvatar(file)
       setValue("avatarUrl", result.url)
+      setAvatarPreview(withApiBase(result.url))
       
       toast({
         title: "Photo updated",


### PR DESCRIPTION
## Summary
- Allow voice call pairing even if partner has no avatar; use fallback instead
- Normalize avatar URLs with API base so profile images display correctly in account settings and voice calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a816321810832d9e4c016fa93824ea