### PR TITLE
Wrap chats page in Suspense boundary

### DIFF
--- a/app/app/chats/page.tsx
+++ b/app/app/chats/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, Suspense } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -115,7 +115,7 @@ const mockMessages = [
   }
 ]
 
-export default function ChatsPage() {
+function ChatsPageContent() {
   const [selectedChat, setSelectedChat] = useState<string | null>(null)
   const [message, setMessage] = useState("")
   const [chatRequests, setChatRequests] = useState<ChatRequest[]>(defaultChatRequests)
@@ -454,5 +454,13 @@ export default function ChatsPage() {
         </div>
       )}
     </div>
+  )
+}
+
+export default function ChatsPage() {
+  return (
+    <Suspense fallback={<div className="p-4">Loading...</div>}>
+      <ChatsPageContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- wrap chats page content in a Suspense boundary to satisfy Next.js build requirements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8289e6270832da6793fef0ca29c97